### PR TITLE
When a user enter a long full name, it was broken. And it fixed

### DIFF
--- a/src/styles/_c-credit-card.scss
+++ b/src/styles/_c-credit-card.scss
@@ -62,6 +62,9 @@
   &__name {
     bottom: 30px;
     left: 30px;
+    text-align: left;
+    line-height: 1.2;
+    max-width: 200px;
   }
 
   &__expire {


### PR DESCRIPTION
When a user wanted to enter a long name such as Haşim Ahmet Abdulbaki Buğra Bahadır YILDIZ, span which has a class name 'c-credit-card__prop c-credit-card__name' has broken. It fixed.